### PR TITLE
added support for the fediverse:creator tag

### DIFF
--- a/content/english/blog/docs-code-examples.md
+++ b/content/english/blog/docs-code-examples.md
@@ -8,6 +8,7 @@ author: "Dachary Carey"
 tags: ["15-20 minutes", "Curious", "Junior", "Senior", "Staff", "Lead"]
 categories: ["Code", "Testing"]
 draft: false
+fediverse_account: "@dachary@dacharycarey.social"
 ---
 
 If you write documentation for a product that is, itself, code - think SDK, API, or CLI - code is an important part of your documentation!

--- a/layouts/partials/essentials/head.html
+++ b/layouts/partials/essentials/head.html
@@ -1,0 +1,64 @@
+<meta charset="utf-8" />
+<title>{{ .Title | default site.Title }}</title>
+
+<!-- responsive meta -->
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5" />
+
+<!-- theme meta -->
+<meta name="theme-name" content="bookworm-hugo" />
+
+<!-- fediverse author link -->
+{{ if .Params.fediverse_account }}
+<meta name="fediverse:creator" content="{{ .Params.fediverse_account }}" />
+{{ else }}
+<meta name="fediverse:creator" content="@techwritingtalks@corporaterunaways.social" />
+{{ end }}
+
+<!-- favicon -->
+{{ partialCached "favicon" . }}
+
+
+<!-- manifest -->
+{{ partialCached "manifest" . }}
+
+
+<!-- site verifications -->
+{{ partialCached "site-verifications.html" . }}
+
+
+<!-- opengraph and twitter card -->
+{{ partial "basic-seo.html" . }}
+
+
+<!-- custom script -->
+{{ partialCached "custom-script.html" . }}
+
+
+<!-- google analytics -->
+{{ template "_internal/google_analytics.html" . }}
+
+
+<!-- google tag manager -->
+{{ partialCached "gtm.html" . }}
+
+
+<!-- matomo analytics -->
+{{ partialCached "matomo-analytics.html" . }}
+
+
+<!--  Baidu analytics -->
+{{ partialCached "baidu-analytics.html" . }}
+
+
+<!-- Plausible Analytics -->
+{{ partialCached "plausible-analytics.html" . }}
+
+
+<!-- Counter Analytics -->
+{{ partialCached "counter-analytics.html" . }}
+
+
+<!-- Crisp Chat -->
+{{ partialCached "crisp-chat.html" . }}
+
+{{ partial "search-index.html" . }}


### PR DESCRIPTION
usage:
IF the author of a given talk has a fediverse account you should add a fediverse_account: frontmatter tag. the value should be the author's account. For example:

fediverse_account: @techwritingtalks@corporaterunaways.social

if they don't have one the template will
use the the account for tech writing talks itself